### PR TITLE
Improve remote handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ The first time Bit requires access to Bitbucket, it will ask for your username
 and an app password. You can create an app password by navigating to _Bitbucket
 settings_, _App passwords_ on the website.
 
+If your repository has multiple remotes pointing to Bitbucket, Bit assumes that
+the primary remote is called either `upstream`, `bitbucket`, or `origin`.
+
 List open pull requests:
 ```
 bit pr list

--- a/bit/bitbucket.py
+++ b/bit/bitbucket.py
@@ -50,7 +50,27 @@ class Client:
 
 
 def repository(path: str = None) -> typing.Optional[str]:
-    for remote in git.remote(path):
+    remotes = git.remote(path)
+    return _preferred_repository(remotes) or _any_repository(remotes)
+
+
+PREFERRED_REMOTE_NAMES = ['upstream', 'bitbucket', 'origin']
+
+
+def _preferred_repository(remotes: typing.Sequence[git.Remote]) -> typing.Optional[str]:
+    remote_urls = {remote.name: remote.url for remote in remotes}
+    for remote_name in PREFERRED_REMOTE_NAMES:
+        remote_url = remote_urls.get(remote_name)
+        if not remote_url:
+            continue
+        repository = _parse_repository(remote_url)
+        if repository:
+            return repository
+    return None
+
+
+def _any_repository(remotes: typing.Sequence[git.Remote]) -> typing.Optional[str]:
+    for remote in remotes:
         repository = _parse_repository(remote.url)
         if repository:
             return repository


### PR DESCRIPTION
If a repository has multiple remotes pointing to Bitbucket, assume that the primary remote is called either `upstream`, `bitbucket`, or `origin`.